### PR TITLE
added hooks to facilitate experiment step bypass

### DIFF
--- a/FACTS.py
+++ b/FACTS.py
@@ -35,6 +35,10 @@ def GeneratePipeline(pcfg, ecfg, pipe_name, exp_dir, stage_names=None, workflow_
     if "input_data_file" in ecfg.keys():
         ecfg['options']['input_data_file'] = ecfg['input_data_file']
 
+    if "input_compressed_data_file" in ecfg.keys():
+        ecfg['options']['input_compressed_data_file'] = ecfg['input_compressed_data_file']
+
+
     # Append the pipeline id to the list of options
     ecfg['options']['pipeline_id'] = pipe_name
 
@@ -102,6 +106,15 @@ def GenerateTask(tcfg, ecfg, pipe_name, stage_name, task_name, workflow_name="",
             if not os.path.isfile(fp):
                 raise(FileNotFoundError("input_data_file: " + fp + " not found!"))
             tcfg['upload_input_data'].append(fp)
+
+    if "input_compressed_data_file" in ecfg.keys():
+        if not "upload_and_extract_input_data" in tcfg.keys():
+            tcfg['upload_and_extract_input_dats'] = []
+        for x in ecfg['input_compressed_data_file']:
+            fp = os.path.join(ecfg['exp_dir'], "input", x)
+            if not os.path.isfile(fp):
+                raise(FileNotFoundError("input_compressed_data_file: " + fp + " not found!"))
+            tcfg['upload_and_extract_input_data'].append(fp)
 
     # Upload data from your local machine to the remote machine
     # Note: Remote machine can be the local machine

--- a/experiments/dummy/config.yml
+++ b/experiments/dummy/config.yml
@@ -1,0 +1,7 @@
+global-options:
+    rcfg-name: "localhost"
+
+sealevel_step:
+    dummy:
+        module_set: "facts"
+        module: "dummy"

--- a/modules/facts/dummy/README.md
+++ b/modules/facts/dummy/README.md
@@ -1,0 +1,3 @@
+# genmod/directsample
+
+This generic module samples directly from a CSV that provides individual samples of values at different time points.

--- a/modules/facts/dummy/facts_dummy_preprocess.py
+++ b/modules/facts/dummy/facts_dummy_preprocess.py
@@ -1,8 +1,5 @@
-import numpy as np
-import csv
 import argparse
-import pickle
-import os
+
 
 ''' facts_dummy_preprocess.py
 

--- a/modules/facts/dummy/facts_dummy_preprocess.py
+++ b/modules/facts/dummy/facts_dummy_preprocess.py
@@ -4,7 +4,7 @@ import argparse
 import pickle
 import os
 
-''' facts_dummy_stage.py
+''' facts_dummy_preprocess.py
 
 This module does nothing, but provides a convenient module to use for
 moving files around on the server as specified in a custom pipeline.yml

--- a/modules/facts/dummy/facts_dummy_stage.py
+++ b/modules/facts/dummy/facts_dummy_stage.py
@@ -1,0 +1,28 @@
+import numpy as np
+import csv
+import argparse
+import pickle
+import os
+
+''' facts_dummy_stage.py
+
+This module does nothing, but provides a convenient module to use for
+moving files around on the server as specified in a custom pipeline.yml
+file. (For example, this could be used to place climate data files
+from a previous run in the $SHARED/climate directory.)
+
+'''
+
+if __name__ == '__main__':
+	
+	# Initialize the command-line argument parser
+	parser = argparse.ArgumentParser(description="Run the facts/dummy module stage.",\
+	epilog="Note: This is meant to be run within the Framework for the Assessment of Changes To Sea-level (FACTS)")
+	
+	# Define the command line arguments to be expected
+	parser.add_argument('--pipeline_id', help="Unique identifier for this instance of the module")
+
+	# Parse the arguments
+	args = parser.parse_args()
+	
+	exit()

--- a/modules/facts/dummy/pipeline.yml
+++ b/modules/facts/dummy/pipeline.yml
@@ -1,0 +1,18 @@
+# Generic Module 'Direct Sample' pipeline
+
+stage:
+  task1:
+    executable: "python"
+    cpu:
+      processes: 1
+      process-type: None
+      threads-per-process: 1
+      thread-type: None
+    script: "facts_dummy_stage.py"
+    options:
+      - "pipeline_id"
+    upload_input_data:
+      - "%MODULE_PATH%/facts_dummy_stage.py"
+    #climate_output_data:
+    #global_total_files:
+    #local_total_files:

--- a/modules/facts/dummy/pipeline.yml
+++ b/modules/facts/dummy/pipeline.yml
@@ -1,6 +1,6 @@
-# Generic Module 'Direct Sample' pipeline
+# FACTS dummy pipeline
 
-stage:
+preprocess:
   task1:
     executable: "python"
     cpu:

--- a/modules/facts/dummy/pipeline.yml
+++ b/modules/facts/dummy/pipeline.yml
@@ -8,11 +8,11 @@ stage:
       process-type: None
       threads-per-process: 1
       thread-type: None
-    script: "facts_dummy_stage.py"
+    script: "facts_dummy_preprocess.py"
     options:
       - "pipeline_id"
     upload_input_data:
-      - "%MODULE_PATH%/facts_dummy_stage.py"
+      - "%MODULE_PATH%/facts_dummy_preprocess.py"
     #climate_output_data:
     #global_total_files:
     #local_total_files:


### PR DESCRIPTION
This pull request (1) allows compressed input files to be specified in experiment config.yml and (2) creates a dummy module that can be used for moving uploaded files around via specification in a custom pipeline.yml file (e.g., upload climate output data files, then list them in pipeline.yml so they end up in $SHARED/climate, or upload custom sea level output files, then list them so they end up $SHARED/to-total.)