### PR TITLE
Added option to connect to HPC using a specific mongodb URL

### DIFF
--- a/runFACTS.py
+++ b/runFACTS.py
@@ -59,7 +59,9 @@ def run_experiment(exp_dir, debug_mode, resourcedir = None, makeshellscript = Fa
     rcfg = facts.LoadResourceConfig(resourcedir, rcfg_name)
 
     # Initialize RCT and the EnTK App Manager
-    if not "mongodb" in rcfg.keys():
+    if 'mongodb_url' in rcfg:
+        dburl = rcfg['mongodb_url']
+    elif not "mongodb" in rcfg.keys():
         dburl = 'mongodb://localhost:27017/facts'
     elif not "password" in rcfg['mongodb'].keys():
         dburl = 'mongodb://%s:%d/facts' % (rcfg['mongodb'].get('hostname', 'localhost'), rcfg['mongodb'].get('port', 27017))


### PR DESCRIPTION
This is an addition to FACTS.py that allows the user the option to submit just the mongodb url in the resource configuration file instead of breaking the mongodb url into specific flags.