### PR TITLE
Mem fix totaling

### DIFF
--- a/modules/ipccar5/icesheets/ipccar5_icesheets_project.py
+++ b/modules/ipccar5/icesheets/ipccar5_icesheets_project.py
@@ -134,11 +134,11 @@ def time_projection(startratemean, startratepm, finalrange, nr, nt, data_years, 
 	# where a is 0.5*acceleration and b is start rate. Hence
 	#		a = S/t**2-b/t
 	momm = 1e-3 # convert mm yr-1 to m yr-1
-	startrate = (startratemean + startratepm * np.array([-1,1], dtype=np.float)) * momm
+	startrate = (startratemean + startratepm * np.array([-1,1], dtype=float)) * momm
 	finalyr = np.arange(nfinal) - nfinal + nyr + 1 # last element ==nyr
 	# If nfinal=1, the following is equivalent to
 	# np.array(finalrange,dtype=np.float)/nyr**2-startrate/nyr
-	acceleration = (np.array(finalrange, dtype=np.float) - startrate * finalyr.mean()) / (finalyr**2).mean()
+	acceleration = (np.array(finalrange, dtype=float) - startrate * finalyr.mean()) / (finalyr**2).mean()
 
 	# Create a field of elapsed time in years
 	time = data_years

--- a/modules/tlm/sterodynamics/tlm_oceandynamics_fit.py
+++ b/modules/tlm/sterodynamics/tlm_oceandynamics_fit.py
@@ -147,7 +147,7 @@ def tlm_fit_oceandynamics(pipeline_id):
 	output = {'ThermExpMean': ThermExpMean, 'ThermExpStd': ThermExpStd,\
 		'ThermExpYears': ThermExpYears,	'ThermExpN': ThermExpN, 'ThermExpDOF': ThermExpDOF}
 	outfile = open(os.path.join(os.path.dirname(__file__), "{}_thermalexp_fit.pkl".format(pipeline_id)), 'wb')
-	pickle.dump(output, outfile)
+	pickle.dump(output, outfile, protocol=4)
 	outfile.close()
 
 
@@ -248,7 +248,7 @@ def tlm_fit_oceandynamics(pipeline_id):
 	output = {'OceanDynMean': OceanDynMean, 'OceanDynStd': OceanDynStd, 'OceanDynDOF': OceanDynDOF, \
 		'OceanDynYears': OceanDynYears,	'OceanDynN': OceanDynN, 'OceanDynTECorr': OceanDynTECorr}
 	outfile = open(os.path.join(os.path.dirname(__file__), "{}_oceandynamics_fit.pkl".format(pipeline_id)), 'wb')
-	pickle.dump(output, outfile)
+	pickle.dump(output, outfile,protocol=4)
 	outfile.close()
 
 
@@ -296,7 +296,7 @@ def tlm_fit_thermalexpansion(pipeline_id):
 	# Write the configuration to a file
 	outdir = os.path.dirname(__file__)
 	outfile = open(os.path.join(outdir, "{}_tlmfit.pkl".format(pipeline_id)), 'wb')
-	pickle.dump(output, outfile)
+	pickle.dump(output, outfile,protocol=4)
 	outfile.close()
 
 	return(None)


### PR DESCRIPTION
Re structured push for memory fixes to FACTS, this includes updating the protocol in tlm_oceandynamics_fit.py, fixing deprecations in numpy as a result of updating to python 3.9 and updating the TotalSamples function in total_workflow.py. 

NOTE: The old TotalSamples is still in totals_workflow.py in case we need to revert it is now called "TotalSamplesOLD"