### PR TITLE
Install EnTK from PyPI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN python3 -m venv --system-site-packages factsVe &&\
 # installs required FACTS packages
 RUN pip install --upgrade \
         setuptools pip wheel \
-        git+https://github.com/radical-cybertools/radical.entk@projects/facts \
+        radical.entk \
         pyyaml==6.0
 
 # installs R for ubuntu2 0.04 Focal

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,5 +46,5 @@ RUN apt-get install -y --no-install-recommends r-base cmake
 RUN mkdir -p ~/radical.pilot.sandbox
 
 # return a shell to the user, starting MDB
-RUN echo -e "/usr/bin/mongod --config /etc/mongod.conf --fork\nsource factsVe/bin/activate" > ~/.bashrc
+RUN echo -e "/usr/bin/mongod --config /etc/mongod.conf --fork\nsource /factsVe/bin/activate" > ~/.bashrc
 CMD /bin/bash

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -40,9 +40,7 @@ Installing and Using FACTS on a GNU/Linux Workstation
 
     python3 -m venv ve3
     . ve3/bin/activate
-    pip install --upgrade setuptools pip wheel
-    pip install git+https://github.com/radical-cybertools/radical.entk@projects/facts
-    pip install pyyaml
+    pip install --upgrade setuptools pip wheel radical.entk pyyaml
 
 5. Test your install by running the dummy experiment::
 


### PR DESCRIPTION
As previously agreed, this installs EnTK from PyPI instead of from the facts branch on github. I tested it with `cd /opt/facts ; python3 runFACTS.py experiments/dummy` and it run successfully.