### PR TITLE
added ability to override global options from commandline

### DIFF
--- a/FACTS.py
+++ b/FACTS.py
@@ -365,7 +365,7 @@ def IdentifyClimateOutputFiles(pcfg,pipe_name):
  
     return pd
 
-def ParseExperimentConfig(exp_dir):
+def ParseExperimentConfig(exp_dir, globalopts=None):
     # Initialize a list for experiment steps (each step being a set of pipelines)
     experimentsteps = {}
 
@@ -400,6 +400,10 @@ def ParseExperimentConfig(exp_dir):
     else:
         global_options['experiment_name'] = os.path.basename(exp_dir)
 
+    if globalopts:
+        for this_mod in globalopts.keys():
+            global_options[this_mod] = globalopts[this_mod]
+    
     # Initialize a list for pipelines
     pipelines = []
     workflows_to_include = {}

--- a/docs/source/configurationfiles.rst
+++ b/docs/source/configurationfiles.rst
@@ -22,6 +22,11 @@ In addition, this section can specify:
 
 * **rcfg-name**: the name of the resource configuration file to be used. FACTS will look in the resources/ directory for file with name *resource_(rcfg_name).yml*. (If not specified, *resource.yml* will be used.)
 
+Global options can be overwritten when runFACTS.py is invokved from the command line by passing a dictionary along with the `--global_options` parameter; for example:
+
+```
+python3 runFACTS.py --global_options '{"rcfg-name": "localhost" }' experiments/dummy/
+```
 
 Experiment step and module configuration
 ----------------------------------------

--- a/docs/source/configurationfiles.rst
+++ b/docs/source/configurationfiles.rst
@@ -24,9 +24,8 @@ In addition, this section can specify:
 
 Global options can be overwritten when runFACTS.py is invokved from the command line by passing a dictionary along with the `--global_options` parameter; for example:
 
-```
-python3 runFACTS.py --global_options '{"rcfg-name": "localhost" }' experiments/dummy/
-```
+    python3 runFACTS.py --global_options '{"rcfg-name": "localhost" }' experiments/dummy/
+
 
 Experiment step and module configuration
 ----------------------------------------

--- a/runFACTS.py
+++ b/runFACTS.py
@@ -8,14 +8,15 @@ import yaml
 from pprint import pprint
 import FACTS as facts
 from radical.entk import AppManager
+import json
 
 
-def run_experiment(exp_dir, debug_mode, alt_id, resourcedir = None, makeshellscript = False):
+def run_experiment(exp_dir, debug_mode, alt_id, resourcedir = None, makeshellscript = False, globalopts = None):
 
     if not resourcedir:
         resourcedir = exp_dir
 
-    expconfig = facts.ParseExperimentConfig(exp_dir)
+    expconfig = facts.ParseExperimentConfig(exp_dir, globalopts=globalopts)
     experimentsteps = expconfig['experimentsteps']
     workflows = expconfig['workflows']
     climate_data_files = expconfig['climate_data_files']
@@ -204,18 +205,19 @@ if __name__ == "__main__":
     parser.add_argument('edir', help="Experiment Directory")
     parser.add_argument('--shellscript', help="Turn experiment config into a shell script (only limited file handling, works best with single-module experiments)", action="store_true")
     parser.add_argument('--debug', help="Enable debug mode (check that configuration files parse, do not execute)", action="store_true")
-    parser.add_argument('--resourcedir', help="Directory containing resource files (default=./resources/)", type=str, default='./resources')
+    parser.add_argument('--resourcedir', help="String containing resource files (default=./resources/)", type=str, default='./resources')
     parser.add_argument('--alt_id', help='If flagged, then the session ID will be in the format EXPNAME.MMDDYYY.HHMMSS', action='store_true')
+    parser.add_argument('--global_options', help='Dictionary of global options to overwrite those specified in config.tml', type=json.loads)
 
     # Parse the arguments
     args = parser.parse_args()
-
+ 
     # Does the experiment directory exist?
     if not os.path.isdir(args.edir):
         print('%s does not exist'.format(args.edir))
         sys.exit(1)
 
     # Go ahead and try to run the experiment
-    run_experiment(args.edir, args.debug, args.alt_id, resourcedir=args.resourcedir, makeshellscript = args.shellscript)
+    run_experiment(args.edir, args.debug, args.alt_id, resourcedir=args.resourcedir, makeshellscript = args.shellscript, globalopts = args.global_options)
 
     #sys.exit(0)

--- a/runFACTS.py
+++ b/runFACTS.py
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     parser.add_argument('edir', help="Experiment Directory")
     parser.add_argument('--shellscript', help="Turn experiment config into a shell script (only limited file handling, works best with single-module experiments)", action="store_true")
     parser.add_argument('--debug', help="Enable debug mode (check that configuration files parse, do not execute)", action="store_true")
-    parser.add_argument('--resourcedir', help="String containing resource files (default=./resources/)", type=str, default='./resources')
+    parser.add_argument('--resourcedir', help="Directory containing resource files (default=./resources/)", type=str, default='./resources')
     parser.add_argument('--alt_id', help='If flagged, then the session ID will be in the format EXPNAME.MMDDYYY.HHMMSS', action='store_true')
     parser.add_argument('--global_options', help='Dictionary of global options to overwrite those specified in config.tml', type=json.loads)
 


### PR DESCRIPTION
Branch should allow global options to be specified as a dictionary and override those specified in config.yml, for example:

```
python3 runFACTS.py --global_options '{"rcfg-name": "localhost" }' experiments/dummy/
```

or

```
python3 runFACTS.py --global_options '{"rcfg-name": "amarel" }' experiments/dummy/
```