### PR TITLE
Allows upload of precomputed climate or sea level data

### DIFF
--- a/FACTS.py
+++ b/FACTS.py
@@ -32,11 +32,10 @@ def GeneratePipeline(pcfg, ecfg, pipe_name, exp_dir, stage_names=None, workflow_
     ecfg['exp_dir'] = exp_dir
 
     # Append the input file to the list of options (if need be)
-    if "input_data_file" in ecfg.keys():
-        ecfg['options']['input_data_file'] = ecfg['input_data_file']
-
-    if "input_compressed_data_file" in ecfg.keys():
-        ecfg['options']['input_compressed_data_file'] = ecfg['input_compressed_data_file']
+    for tagtoappend in {'input_data_file','input_compressed_data_file','climate_output_data', \
+                        'global_total_files','local_total_files','totaled_files'}:
+        if tagtoappend in ecfg.keys():
+            ecfg['options'][tagtoappend] = ecfg[tagtoappend]
 
 
     # Append the pipeline id to the list of options
@@ -113,7 +112,6 @@ def GenerateTask(tcfg, ecfg, pipe_name, stage_name, task_name, workflow_name="",
         tcfg['upload_and_extract_input_data'] = []
 
     # If there's a user-defined input file, add it to the upload list
-
     if "input_data_file" in ecfg['options'].keys():
          for x in ecfg['options']['input_data_file']:
             fp = os.path.join(ecfg['exp_dir'], "input", mvar_replace_dict(mvar_dict,x))
@@ -242,6 +240,7 @@ def GenerateTask(tcfg, ecfg, pipe_name, stage_name, task_name, workflow_name="",
                                 for x in tcfg['local_total_files']])
         download_list.extend(['{0} > {1}/{0}'.format(mvar_replace_dict(mvar_dict, x), outdir)
                              for x in tcfg['local_total_files']])
+
     if "totaled_files" in tcfg.keys():
         copy_output_list.extend(['{0} > $SHARED/totaled/{0}'.format(mvar_replace_dict(mvar_dict, x))
                                 for x in tcfg['totaled_files']])
@@ -255,6 +254,24 @@ def GenerateTask(tcfg, ecfg, pipe_name, stage_name, task_name, workflow_name="",
                                 for x in ecfg['options']['climate_output_data']])
         download_list.extend(['{0} > {1}/{0}'.format(mvar_replace_dict(mvar_dict, x), outdir)
                              for x in ecfg['options']['climate_output_data']])
+
+    if "global_total_files" in ecfg['options'].keys():
+        copy_output_list.extend(['{0} > $SHARED/to_total/global/{0}'.format(mvar_replace_dict(mvar_dict, x))
+                                for x in ecfg['options']['global_total_files']])
+        download_list.extend(['{0} > {1}/{0}'.format(mvar_replace_dict(mvar_dict, x), outdir)
+                             for x in ecfg['options']['global_total_files']])
+
+    if "local_total_files" in ecfg['options'].keys():
+        copy_output_list.extend(['{0} > $SHARED/to_total/local/{0}'.format(mvar_replace_dict(mvar_dict, x))
+                                for x in ecfg['options']['local_total_files']])
+        download_list.extend(['{0} > {1}/{0}'.format(mvar_replace_dict(mvar_dict, x), outdir)
+                             for x in ecfg['options']['local_total_files']])
+
+    if "totaled_files" in ecfg['options'].keys():
+        copy_output_list.extend(['{0} > $SHARED/totaled/{0}'.format(mvar_replace_dict(mvar_dict, x))
+                                for x in ecfg['options']['totaled_files']])
+        download_list.extend(['{0} > {1}/{0}'.format(mvar_replace_dict(mvar_dict, x), outdir)
+                             for x in ecfg['options']['totaled_files']])
 
     # Append the "total" lists to the copy output list
     t.copy_output_data = list(set(copy_output_list))

--- a/FACTS.py
+++ b/FACTS.py
@@ -365,7 +365,7 @@ def IdentifyClimateOutputFiles(pcfg,pipe_name):
  
     return pd
 
-def ParseExperimentConfig(exp_dir):
+def ParseExperimentConfig(exp_dir, globalopts=None):
     # Initialize a list for experiment steps (each step being a set of pipelines)
     experimentsteps = {}
 
@@ -400,6 +400,10 @@ def ParseExperimentConfig(exp_dir):
     else:
         global_options['experiment_name'] = os.path.basename(exp_dir)
 
+    if globalopts:
+        for this_mod in globalopts.keys():
+            global_options[this_mod] = globalopts[this_mod]
+    
     # Initialize a list for pipelines
     pipelines = []
     workflows_to_include = {}

--- a/FACTS.py
+++ b/FACTS.py
@@ -248,6 +248,14 @@ def GenerateTask(tcfg, ecfg, pipe_name, stage_name, task_name, workflow_name="",
         download_list.extend(['{0} > {1}/{0}'.format(mvar_replace_dict(mvar_dict, x), outdir)
                              for x in tcfg['totaled_files']])                                
 
+    # allow experiment config to specify file
+
+    if "climate_output_data" in ecfg['options'].keys():
+        copy_output_list.extend(['{0} > $SHARED/climate/{0}'.format(mvar_replace_dict(mvar_dict, x))
+                                for x in ecfg['options']['climate_output_data']])
+        download_list.extend(['{0} > {1}/{0}'.format(mvar_replace_dict(mvar_dict, x), outdir)
+                             for x in ecfg['options']['climate_output_data']])
+
     # Append the "total" lists to the copy output list
     t.copy_output_data = list(set(copy_output_list))
 

--- a/docs/source/configurationfiles.rst
+++ b/docs/source/configurationfiles.rst
@@ -54,6 +54,8 @@ The following third-level entries are used under the module label:
 
 * **loop_over_scales**: If defined, replicate the module for both global and local scale (e.g., for a totaling module).
 
+* **climate_output_data**, **global_total_files**, **local_total_files**, **totaled_files**: See definitions in pipeline configuration file specification. Can be used together with the `facts/dummy` module and `input_data_file` to upload outputs produced by prior Experiment Steps and have them filed in an appropriate directory for subsequent modules to find. 
+
 
 Example experiment file
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/experiments/dummy.input/config.yml
+++ b/experiments/dummy.input/config.yml
@@ -1,0 +1,8 @@
+climate_step:
+    dummy:
+        module_set: "facts"
+        module: "dummy"
+        input_data_file:
+            - "test.txt"
+        climate_output_data:
+            - "test.txt"

--- a/runFACTS.py
+++ b/runFACTS.py
@@ -8,14 +8,15 @@ import yaml
 from pprint import pprint
 import FACTS as facts
 from radical.entk import AppManager
+import json
 
 
-def run_experiment(exp_dir, debug_mode, alt_id, resourcedir = None, makeshellscript = False):
+def run_experiment(exp_dir, debug_mode, alt_id, resourcedir = None, makeshellscript = False, globalopts = None):
 
     if not resourcedir:
         resourcedir = exp_dir
 
-    expconfig = facts.ParseExperimentConfig(exp_dir)
+    expconfig = facts.ParseExperimentConfig(exp_dir, globalopts=globalopts)
     experimentsteps = expconfig['experimentsteps']
     workflows = expconfig['workflows']
     climate_data_files = expconfig['climate_data_files']
@@ -204,18 +205,19 @@ if __name__ == "__main__":
     parser.add_argument('edir', help="Experiment Directory")
     parser.add_argument('--shellscript', help="Turn experiment config into a shell script (only limited file handling, works best with single-module experiments)", action="store_true")
     parser.add_argument('--debug', help="Enable debug mode (check that configuration files parse, do not execute)", action="store_true")
-    parser.add_argument('--resourcedir', help="Directory containing resource files (default=./resources/)", type=str, default='./resources')
+    parser.add_argument('--resourcedir', help="String containing resource files (default=./resources/)", type=str, default='./resources')
     parser.add_argument('--alt_id', help='If flagged, then the session ID will be in the format EXPNAME.MMDDYYY.HHMMSS', action='store_true')
+    parser.add_argument('--global_options', help='Dictionary of global options to overwrite those specified in config.tml', type=json.loads)
 
     # Parse the arguments
     args = parser.parse_args()
-
+ 
     # Does the experiment directory exist?
     if not os.path.isdir(args.edir):
         print('%s does not exist'.format(args.edir))
         sys.exit(1)
 
     # Go ahead and try to run the experiment
-    run_experiment(args.edir, args.debug, args.alt_id, resourcedir=args.resourcedir, makeshellscript = args.shellscript)
+    run_experiment(args.edir, args.debug, args.alt_id, resourcedir=args.resourcedir, makeshellscript = args.shellscript, globalopts = args.global_options)
 
     #sys.exit(0)

--- a/runFACTS.py
+++ b/runFACTS.py
@@ -214,7 +214,7 @@ if __name__ == "__main__":
  
     # Does the experiment directory exist?
     if not os.path.isdir(args.edir):
-        print('%s does not exist'.format(args.edir))
+        print('{0} does not exist'.format(args.edir))
         sys.exit(1)
 
     # Go ahead and try to run the experiment

--- a/runFACTS.py
+++ b/runFACTS.py
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     parser.add_argument('edir', help="Experiment Directory")
     parser.add_argument('--shellscript', help="Turn experiment config into a shell script (only limited file handling, works best with single-module experiments)", action="store_true")
     parser.add_argument('--debug', help="Enable debug mode (check that configuration files parse, do not execute)", action="store_true")
-    parser.add_argument('--resourcedir', help="String containing resource files (default=./resources/)", type=str, default='./resources')
+    parser.add_argument('--resourcedir', help="Directory containing resource files (default=./resources/)", type=str, default='./resources')
     parser.add_argument('--alt_id', help='If flagged, then the session ID will be in the format EXPNAME.MMDDYYY.HHMMSS', action='store_true')
     parser.add_argument('--global_options', help='Dictionary of global options to overwrite those specified in config.tml', type=json.loads)
 


### PR DESCRIPTION
Suppose you have climate data files that are precomputed. This branch allows you to use the dummy module to upload these file and place them where they can be found by subsequent steps. For example:
```
climate_step:
    dummy:
        module_set: "facts"
        module: "dummy"
        input_data_file:
            - "test.txt"
        climate_output_data:
            - "test.txt"
```

assuming test.txt is in the input subdirectory of the experiment directory.