### PR TITLE
Corrected isssue/potential typo in ohc_samps_idx from initial pass

### DIFF
--- a/modules/tlm/sterodynamics/tlm_oceandynamics_project.py
+++ b/modules/tlm/sterodynamics/tlm_oceandynamics_project.py
@@ -211,8 +211,8 @@ def tlm_project_thermalexpansion(seed, nsamps, pipeline_id):
 	include_models = my_data['include_models']
 
 	# Generate indices that sample from OHC values
-	ohc_samps_idx = np.random.choice(np.arange(ohc_samps.shape[0]), nsamps)
-	ohc_samps_idx = np.arange(names)
+	#ohc_samps_idx = np.random.choice(np.arange(ohc_samps.shape[0]), nsamps)
+	ohc_samps_idx = np.arange(ohc_samps.shape[0])
 	ohc_samps = ohc_samps[ohc_samps_idx,:]
 
 	# Generate samples assuming normal distribution


### PR DESCRIPTION
Originally line 214 in tlm_oceandynamics_project.py was 
ohc_samps_idx = np.arange(names)

Which caused the module to fail as names isn't traced.
Corrected to 
ohc_samps_idx = np.arange(ohc_samps.shape[0])

So that the ohc sample indices are now just an array based on the length of the ohc_samps