### PR TITLE
Commented out throwing away low frequencies in extremesealevel_points…

### DIFF
--- a/modules/extremesealevel/pointsoverthreshold/extremesealevel_pointsoverthreshold_project.py
+++ b/modules/extremesealevel/pointsoverthreshold/extremesealevel_pointsoverthreshold_project.py
@@ -85,7 +85,7 @@ def getFreqFromZ_ESL(scale, shape, loc, avg_exceed, z, mhhw, mhhwFreq):
 	log_freq[sub] = np.log(avg_exceed) + ( np.log(mhhwFreq)-np.log(avg_exceed) )*(z0[sub]/(mhhw-loc)) #from Gumbel (see Buchanan et al. 2016 & LocalizeSL) for testz<loc (logN linear in z, assume MHHW once every 2 days)
 	freq[sub] = np.exp( log_freq[sub] )
 	
-	freq[np.less(freq, 1e-6, where=~np.isnan(freq))] = np.nan #throw away frequencies lower than 1e-6 (following SROCC scripts)
+	#freq[np.less(freq, 1e-6, where=~np.isnan(freq))] = np.nan #throw away frequencies lower than 1e-6 (following SROCC scripts)
 	
 	return freq
 


### PR DESCRIPTION
…overthreshold_project.py

This step was inherited from the SROCC code to prevent 'numerical instabilities', but it introduces artefacts in the return curves at the lowest frequencies, where for some GPD samples these evaluate to z=NaN and for others z=finite, resulting in quantile values of z(f) to be based on only part of the GPD samples. I think this improves if f<1e-6 is not set to NaN except if not supported by the GPD, which is already done. Should not affect AFs as long as f_ref=HCE is used.