### PR TITLE
Download OceanDyn.nc in tlm/sterodynamics

### DIFF
--- a/modules/tlm/sterodynamics/pipeline.yml
+++ b/modules/tlm/sterodynamics/pipeline.yml
@@ -110,3 +110,5 @@ postprocess:
           - "%PIPELINE_ID%_projections.pkl"
     local_total_files:
       - "%PIPELINE_ID%_localsl.nc"
+    download_output_data:
+      - "%PIPELINE_ID%_OceanDyn.nc"


### PR DESCRIPTION
Add OceanDyn.nc to the download pipeline for tlm/sterodynamics postprocess.

Please test by running tlm/sterodynamics on at least three grid cells. Inspect the downloaded file to ensure it includes OceanDynN for each grid cell.