### PR TITLE
Fixed deprecated numpy functions

### DIFF
--- a/modules/FittedISMIP/GrIS/Import2lmData.py
+++ b/modules/FittedISMIP/GrIS/Import2lmData.py
@@ -143,7 +143,7 @@ maximum temperature falling between two values over a span of time.
 Returns a dictionary with "samples" = [matched_samples, years] and "years" = [years]
 
 '''
-def Filter2lmData(tlm_dict, filter_years=None, tmin=np.NINF, tmax=np.PINF):
+def Filter2lmData(tlm_dict, filter_years=None, tmin=-np.inf, tmax=np.inf):
 
 	# Extract the data from the dict
 	samps = tlm_dict["samples"]

--- a/modules/ipccar5/glaciers/Import2lmData.py
+++ b/modules/ipccar5/glaciers/Import2lmData.py
@@ -143,7 +143,7 @@ maximum temperature falling between two values over a span of time.
 Returns a dictionary with "samples" = [matched_samples, years] and "years" = [years]
 
 '''
-def Filter2lmData(tlm_dict, filter_years=None, tmin=np.NINF, tmax=np.PINF):
+def Filter2lmData(tlm_dict, filter_years=None, tmin=-np.inf, tmax=np.inf):
 
 	# Extract the data from the dict
 	samps = tlm_dict["samples"]

--- a/modules/ipccar5/icesheets/Import2lmData.py
+++ b/modules/ipccar5/icesheets/Import2lmData.py
@@ -143,7 +143,7 @@ maximum temperature falling between two values over a span of time.
 Returns a dictionary with "samples" = [matched_samples, years] and "years" = [years]
 
 '''
-def Filter2lmData(tlm_dict, filter_years=None, tmin=np.NINF, tmax=np.PINF):
+def Filter2lmData(tlm_dict, filter_years=None, tmin=-np.inf, tmax=np.inf):
 
 	# Extract the data from the dict
 	samps = tlm_dict["samples"]

--- a/modules/ipccar6/larmipAIS/Import2lmData.py
+++ b/modules/ipccar6/larmipAIS/Import2lmData.py
@@ -183,7 +183,7 @@ maximum temperature falling between two values over a span of time.
 Returns a dictionary with "samples" = [matched_samples, years] and "years" = [years]
 
 '''
-def Filter2lmData(tlm_dict, filter_years=None, tmin=np.NINF, tmax=np.PINF):
+def Filter2lmData(tlm_dict, filter_years=None, tmin=-np.inf, tmax=np.inf):
 
 	# Extract the data from the dict
 	samps = tlm_dict["samples"]

--- a/modules/tlm/sterodynamics/Import2lmData.py
+++ b/modules/tlm/sterodynamics/Import2lmData.py
@@ -143,7 +143,7 @@ maximum temperature falling between two values over a span of time.
 Returns a dictionary with "samples" = [matched_samples, years] and "years" = [years]
 
 '''
-def Filter2lmData(tlm_dict, filter_years=None, tmin=np.NINF, tmax=np.PINF):
+def Filter2lmData(tlm_dict, filter_years=None, tmin=-np.inf, tmax=np.inf):
 
 	# Extract the data from the dict
 	samps = tlm_dict["samples"]


### PR DESCRIPTION
"Changed deprecated tmin=np.NINF and tmax=np.PINF in Import2lData.py module function Filter2lmData to -np.inf and np.inf where applicable"