### PR TITLE
radical, R version update

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal AS facts-core
+FROM ubuntu:noble AS facts-core
 
 # set env variables for RCT and apt
 ENV DEBIAN_FRONTEND="noninteractive"
@@ -9,9 +9,9 @@ SHELL [ "/bin/bash", "-c" ]
 # installs dependences
 RUN apt-get update &&\
     apt-get install -y \
-        python3.9 \
+        python3-full \
         python3-pip \
-        python3.8-venv \
+        python3-venv \
         git \
         sudo \
         libhdf5-dev \
@@ -23,25 +23,25 @@ RUN apt-get update &&\
         iputils-ping
 
 # Creates and activates python3 virtual environment
-RUN python3 -m venv --system-site-packages factsVe &&\
-    source factsVe/bin/activate
+RUN python3 -m venv factsVe
+RUN source /factsVe/bin/activate
 
 # installs required FACTS packages
-RUN pip install --no-cache-dir --upgrade \
-        setuptools==69.0.2 pip==23.3.1 wheel==0.42.0
+RUN /factsVe/bin/pip install --no-cache-dir --upgrade \
+        setuptools==75.8.2 pip==25.0.1 wheel==0.45.1
 
-RUN pip install --no-cache-dir \
-        radical.entk==1.52.0 \
-        radical.gtod==1.52.0 \
-        radical.pilot==1.52.1 \
-        radical.saga==1.52.0 \
-        radical.utils==1.52.0 \
-        pyyaml==6.0.1 \
-        xarray==2023.1.0 \
-        numpy==1.24.4 \
-        netcdf4==1.6.5 \
-        h5py \
-        dask
+RUN /factsVe/bin/pip install --no-cache-dir \
+        radical.entk==1.92.0 \
+        radical.gtod==1.90.0 \
+        radical.pilot==1.92.0 \
+        radical.saga==1.90.0 \
+        radical.utils==1.91.1 \
+        pyyaml==6.0.2 \
+        xarray==2025.1.2 \
+        numpy==2.2.3 \
+        netcdf4==1.7.2 \
+        h5py==3.13.0 \
+        dask==2025.2.0
 
         
 # installs R for ubuntu 20.04 Focal
@@ -53,10 +53,10 @@ RUN apt-get update &&\
 
 
 ARG NB_USER=jovyan
-ARG NB_UID=1000
-ENV USER ${NB_USER}
-ENV NB_UID ${NB_UID}
-ENV HOME /home/${NB_USER}
+ARG NB_UID=1001
+ENV USER=${NB_USER}
+ENV NB_UID=${NB_UID}
+ENV HOME=/home/${NB_USER}
 
 RUN adduser --disabled-password \
     --gecos "Default user" \
@@ -66,6 +66,8 @@ RUN adduser --disabled-password \
 # Make sure the contents of our repo are in ${HOME}
 USER root
 RUN chown -R ${NB_UID} ${HOME}
+RUN chown -R ${NB_UID} /factsVe
+RUN chown -R ${NB_UID} /usr/local/lib/R/site-library
 USER ${NB_USER}
 
 # make directory for radical pilot sandbox
@@ -90,12 +92,12 @@ CMD /bin/bash
 FROM facts-core AS facts-jupyter
 
 USER root
-RUN pip install --no-cache-dir \
-	matplotlib==3.7.4 \
-	notebook==7.0.6 \
-	jupyterlab==4.0.9 \
-	jupyter==1.0.0
-
+RUN /factsVe/bin/pip install --no-cache-dir \
+	matplotlib==3.10.1 \
+	notebook==7.3.2 \
+	jupyterlab==4.3.5 \
+	jupyter==1.1.1
+RUN chown -R ${NB_UID} /factsVe
 EXPOSE 8888
 USER ${NB_USER}
 

--- a/docker/develop.sh
+++ b/docker/develop.sh
@@ -3,8 +3,8 @@
 TAG="facts"
 
 echo "Build docker container $TAG"
-docker build --no-cache --target facts-core -t "$TAG" .
+docker build --target facts-core -t "$TAG" .
 
 TAG="facts-jupyter"
 echo "Build docker container $TAG"
-docker build --no-cache --target facts-jupyter -t "$TAG" .
+docker build --target facts-jupyter -t "$TAG" .

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -34,7 +34,7 @@ Installing and Using FACTS on a GNU/Linux Workstation
     python3 -m venv ve3
     . ve3/bin/activate
     pip install --upgrade setuptools pip wheel
-    pip install radical.entk pyyaml
+    pip install -r facts/facts_requirments.txt
 
 4. Test your install by running the dummy experiment::
 

--- a/facts_requirments.txt
+++ b/facts_requirments.txt
@@ -1,8 +1,8 @@
-radical.entk==1.52.0 
-radical.gtod==1.52.0 
-radical.pilot==1.52.1 
-radical.saga==1.52.0 
-radical.utils==1.52.0 
+radical.entk==1.92.0 
+radical.gtod==1.90.0 
+radical.pilot==1.92.0 
+radical.saga==1.90.0 
+radical.utils==1.91.1 
 pyyaml==6.0.1
 xarray==2023.1.0
 netcdf4==1.6.5

--- a/modules/emulandice/shared/emulandice_environment.sh
+++ b/modules/emulandice/shared/emulandice_environment.sh
@@ -11,7 +11,7 @@ if [ ${hs: -18} = 'amarel.rutgers.edu' ]; then
 
     module purge
     module load intel/19.0.3
-    module load R/3.6.3-gc563
+    module load R/4.1.0-gc563
     module load gcc/7.3.0-gc563
     module load cmake/3.24.3-sw1088
 


### PR DESCRIPTION
Update `radical` version for FACTS so the `venv` works on Linux machines. R v3 is deprecated, so it has been updated to use R v4. *Note: These changes have already been applied in the [Docker image commit](https://github.com/radical-collaboration/facts/commit/aa834869876ad2e27589e76a629d4d5a9eebe9e7).*

- Tested with [ssp585](https://github.com/radical-collaboration/facts/blob/main/experiments/coupling.ssp585/config.yml)
   
<br>

I also updated the [`quickstart`](https://github.com/radical-collaboration/facts/blob/main/docs/source/quickstart.rst) instructions to install dependencies from [`facts_requirements.txt`](https://github.com/radical-collaboration/facts/blob/main/facts_requirments.txt)